### PR TITLE
EmitJSON: actually send out data

### DIFF
--- a/wsevent.go
+++ b/wsevent.go
@@ -118,6 +118,9 @@ func (c *Client) EmitJSON(v interface{}) error {
 	js := emitPool.Get().(emitJS)
 	defer emitPool.Put(js)
 
+	js.Id = -1
+	js.Data = v
+
 	return c.conn.WriteJSON(js)
 }
 


### PR DESCRIPTION
Currently, wsevent is only sending `{"id":0,"data":null}` messages
